### PR TITLE
Autoload

### DIFF
--- a/src/ObjRender.cpp
+++ b/src/ObjRender.cpp
@@ -68,7 +68,7 @@ get_mesh_data(
 
 void ObjRender::Init()
 {
-	_program = new ShadingProgram(_vertexPath, _fragPath);
+	_program = new ShadingProgram(_vertexPath, _fragPath, true);
 }
 
 
@@ -184,7 +184,6 @@ void ObjRender::Render(
 	const CameraData& cam_data,
 	const std::vector<glm::mat4>& transforms)
 {
-	_program->Update();
 	_program->Use();
 	glBindTexture(GL_TEXTURE_2D, _texID);
 	glActiveTexture(GL_TEXTURE0);

--- a/src/ObjRender.cpp
+++ b/src/ObjRender.cpp
@@ -7,11 +7,6 @@
 
 ShadingProgram* ObjRender::_program = nullptr;
 
-GLuint ObjRender::_worldToScreenID;
-GLuint ObjRender::_camPosID;
-GLuint ObjRender::_texLocID;
-GLuint ObjRender::_transformID;
-
 static void
 get_mesh_data(
 	const std::string& filepath,
@@ -74,10 +69,6 @@ get_mesh_data(
 void ObjRender::Init()
 {
 	_program = new ShadingProgram(_vertexPath, _fragPath);
-	_worldToScreenID = glGetUniformLocation(_program->ID(), "worldToScreen");
-	_transformID = glGetUniformLocation(_program->ID(), "transform");
-	_camPosID = glGetUniformLocation(_program->ID(), "camPos");
-	_texLocID = glGetUniformLocation(_program->ID(), "tex");
 }
 
 
@@ -193,14 +184,15 @@ void ObjRender::Render(
 	const CameraData& cam_data,
 	const std::vector<glm::mat4>& transforms)
 {
+	_program->Update();
 	_program->Use();
 	glBindTexture(GL_TEXTURE_2D, _texID);
 	glActiveTexture(GL_TEXTURE0);
-	glUniform1i(_texLocID, 0);
+	glUniform1i(_program->Uniform("tex"), 0);
 
 	glBindVertexArray(_VAO);
-	glUniform3fv(_camPosID, 1, &cam_data.position[0]);
-	glUniformMatrix4fv(_worldToScreenID, 1, GL_FALSE,
+	glUniform3fv(_program->Uniform("worldToScreen"), 1, &cam_data.position[0]);
+	glUniformMatrix4fv(_program->Uniform("worldToScreen"), 1, GL_FALSE,
 		glm::value_ptr(cam_data.worldToScreen));
 
 
@@ -209,7 +201,7 @@ void ObjRender::Render(
 	glCullFace(GL_BACK);
 	for (auto& transform : transforms)
 	{
-		glUniformMatrix4fv(_transformID, 1, GL_FALSE,
+		glUniformMatrix4fv(_program->Uniform("transform"), 1, GL_FALSE,
 			glm::value_ptr(transform));
 		glDrawArrays(GL_TRIANGLES, 0, _vertexCount);
 	}

--- a/src/ObjRender.cpp
+++ b/src/ObjRender.cpp
@@ -191,7 +191,7 @@ void ObjRender::Render(
 	glUniform1i(_program->Uniform("tex"), 0);
 
 	glBindVertexArray(_VAO);
-	glUniform3fv(_program->Uniform("worldToScreen"), 1, &cam_data.position[0]);
+	glUniform3fv(_program->Uniform("campos"), 1, &cam_data.position[0]);
 	glUniformMatrix4fv(_program->Uniform("worldToScreen"), 1, GL_FALSE,
 		glm::value_ptr(cam_data.worldToScreen));
 

--- a/src/ObjRender.cpp
+++ b/src/ObjRender.cpp
@@ -102,6 +102,13 @@ ObjRender::ObjRender(const std::string& filepath)
 	_loadTexture(_texDir + textures[0]);
 }
 
+ObjRender::~ObjRender()
+{
+	glDeleteVertexArrays(1, &_VAO);
+	glDeleteBuffers(1, &_trianglesID);
+	glDeleteBuffers(1, &_uvsID);
+	glDeleteBuffers(1, &_normalsID);
+}
 
 void
 ObjRender::_loadArrayBuffers(

--- a/src/ObjRender.hpp
+++ b/src/ObjRender.hpp
@@ -19,12 +19,6 @@ class ObjRender
 
 	static ShadingProgram* _program;
 
-	// uniforms
-	static GLuint _worldToScreenID;
-	static GLuint _camPosID;
-	static GLuint _texLocID;
-	static GLuint _transformID;
-
 	GLuint _texID;
 	GLuint _trianglesID;
 	GLuint _uvsID;

--- a/src/ObjRender.hpp
+++ b/src/ObjRender.hpp
@@ -47,6 +47,7 @@ public:
 	static void Init();
 
 	ObjRender(const std::string& filepath);
+	~ObjRender();
 
 	// render transforms.size() objects
 	void Render(

--- a/src/ShaderObj.cpp
+++ b/src/ShaderObj.cpp
@@ -3,15 +3,6 @@
 ShaderObj::ShaderObj(const std::string& fragpath)
 {
 	_program = new ShadingProgram(_vertexPath, fragpath);
-	_transformID = glGetUniformLocation(_program->ID(), "transform");
-	_inverseTransformID = glGetUniformLocation(_program->ID(), "inverseTransform");
-	_camPosID = glGetUniformLocation(_program->ID(), "camPos");
-	_screenToWorldID = glGetUniformLocation(_program->ID(), "screenToWorld");
-	_worldToScreenID = glGetUniformLocation(_program->ID(), "worldToScreen");
-	_lightPosID = glGetUniformLocation(_program->ID(), "lightPos");
-	_lightColorID = glGetUniformLocation(_program->ID(), "lightColor");
-	_lightNumID = glGetUniformLocation(_program->ID(), "lightNum");
-	_timeID = glGetUniformLocation(_program->ID(), "time");
 	_loadArrayBuffers();
 	_makeVAO();
 }
@@ -102,30 +93,30 @@ void ShaderObj::_render(
 	size = std::min(size, 99);
 	if (size)
 	{
-		glUniform3fv(_lightPosID,
+		glUniform3fv(_program->Uniform("lightPos"),
 			size,
 			reinterpret_cast<const GLfloat*>(&(Light::positions[0].x)));
-		glUniform3fv(_lightColorID,
+		glUniform3fv(_program->Uniform("lightColor"),
 			size,
 			reinterpret_cast<const GLfloat*>(&(Light::colors[0].x)));
 	}
-	glUniform1i(_lightNumID, size);
+	glUniform1i(_program->Uniform("lightNum"), size);
 
-	glUniform1f(_timeID, _total_time);
+	glUniform1f(_program->Uniform("time"), _total_time);
 
-	glUniform3fv(_camPosID, 1, &cam_data.position[0]);
+	glUniform3fv(_program->Uniform("camPos"), 1, &cam_data.position[0]);
 
 	glm::mat4 screenToWorld = glm::inverse(cam_data.worldToScreen);
 
-	glUniformMatrix4fv(_screenToWorldID, 1, GL_FALSE,
+	glUniformMatrix4fv(_program->Uniform("screenToWorld"), 1, GL_FALSE,
 		glm::value_ptr(screenToWorld));
-	glUniformMatrix4fv(_worldToScreenID, 1, GL_FALSE,
+	glUniformMatrix4fv(_program->Uniform("worldToScreen"), 1, GL_FALSE,
 		glm::value_ptr(cam_data.worldToScreen));
 
 	glm::mat4 inverse_transform = glm::inverse(transform);
-	glUniformMatrix4fv(_inverseTransformID, 1, GL_FALSE,
+	glUniformMatrix4fv(_program->Uniform("inverseTransform"), 1, GL_FALSE,
 		glm::value_ptr(inverse_transform));
-	glUniformMatrix4fv(_transformID, 1, GL_FALSE,
+	glUniformMatrix4fv(_program->Uniform("transform"), 1, GL_FALSE,
 		glm::value_ptr(transform));
 
 	glEnable(GL_CULL_FACE);

--- a/src/ShaderObj.cpp
+++ b/src/ShaderObj.cpp
@@ -16,6 +16,13 @@ ShaderObj::ShaderObj(const std::string& fragpath)
 	_makeVAO();
 }
 
+ShaderObj::~ShaderObj()
+{
+	delete _program;
+	glDeleteVertexArrays(1, &_VAO);
+	glDeleteBuffers(1, &_cubeID);
+}
+
 void ShaderObj::_loadArrayBuffers()
 {
 	const GLfloat cube[] = {

--- a/src/ShaderObj.cpp
+++ b/src/ShaderObj.cpp
@@ -2,7 +2,7 @@
 
 ShaderObj::ShaderObj(const std::string& fragpath)
 {
-	_program = new ShadingProgram(_vertexPath, fragpath);
+	_program = new ShadingProgram(_vertexPath, fragpath, true);
 	_loadArrayBuffers();
 	_makeVAO();
 }

--- a/src/ShaderObj.hpp
+++ b/src/ShaderObj.hpp
@@ -38,6 +38,7 @@ class ShaderObj : public Transparency
 
 public:
 	ShaderObj(const std::string& fragpath);
+	~ShaderObj();
 
 	void Render(
 		const CameraData& cam_data,

--- a/src/ShaderObj.hpp
+++ b/src/ShaderObj.hpp
@@ -11,19 +11,8 @@ class ShaderObj : public Transparency
 {
 	static constexpr const char* _vertexPath = "src/shaders/shaderobj.vert";
 
-	GLuint _camPosID;
-	GLuint _transformID;
-	GLuint _inverseTransformID;
-	GLuint _screenToWorldID;
-	GLuint _worldToScreenID;
 	GLuint _cubeID;
 	GLuint _VAO;
-
-	GLuint _lightPosID;
-	GLuint _lightColorID;
-	GLuint _lightNumID;
-
-	GLuint _timeID;
 
 	ShadingProgram* _program;
 

--- a/src/ShadingProgram.cpp
+++ b/src/ShadingProgram.cpp
@@ -2,45 +2,88 @@
 
 ShadingProgram::ShadingProgram(std::string vp, std::string fp)
 {
-	std::string shader;
-	GLuint shader_id;
-	const GLchar *source;
-
-	_program = glCreateProgram();
-
-	shader = GetShaderCode(vp);
-	shader_id = glCreateShader(GL_VERTEX_SHADER);
-	source = shader.c_str();
-	glShaderSource(shader_id, 1, &source, nullptr);
-	glCompileShader(shader_id);
-	CheckCompilation(shader_id, vp);
-	glAttachShader(_program, shader_id);
-
-	shader = GetShaderCode(fp);
-	shader_id = glCreateShader(GL_FRAGMENT_SHADER);
-	source = shader.c_str();
-	glShaderSource(shader_id, 1, &source, nullptr);
-	glCompileShader(shader_id);
-	CheckCompilation(shader_id, fp);
-	glAttachShader(_program, shader_id);
-	glLinkProgram(_program);
-	CheckLinking();
+	_vertex = vp;
+	_fragment = fp;
+	_program = 0;
+	_vertexShaderID = 0;
+	_fragmentShaderID = 0;
+	_recompileProgram(false, false);
 }
 
-std::string	ShadingProgram::GetShaderCode(std::string filepath)
+ShadingProgram::~ShadingProgram()
+{
+	glDeleteShader(_vertexShaderID);
+	glDeleteShader(_fragmentShaderID);
+	glDeleteProgram(_program);
+}
+
+void ShadingProgram::_recompileProgram(bool keepVert, bool keepFrag)
+{
+	if (keepVert && keepFrag)
+		return;
+	if (!keepVert)
+	{
+		glDeleteShader(_vertexShaderID);
+		_vertexShaderID = _compileVertexShader();
+	}
+	if (!keepFrag)
+	{
+		glDeleteShader(_fragmentShaderID);
+		_fragmentShaderID = _compileFragmentShader();
+	}
+	glDeleteProgram(_program);
+	_program = glCreateProgram();
+
+	glAttachShader(_program, _vertexShaderID);
+	glAttachShader(_program, _fragmentShaderID);
+	glLinkProgram(_program);
+	_checkLinking();
+}
+
+GLuint ShadingProgram::_compileVertexShader()
+{
+	struct stat result;
+	if (stat(_vertex.c_str(), &result) == 0)
+		_vertexModify = result.st_mtime;
+
+	GLuint shader_id = glCreateShader(GL_VERTEX_SHADER);
+	_vertexCode = _getShaderCode(_vertex);
+	const GLchar* source = _vertexCode.c_str();
+	glShaderSource(shader_id, 1, &source, nullptr);
+	glCompileShader(shader_id);
+	_checkCompilation(shader_id, _vertex);
+	return shader_id;
+}
+
+GLuint ShadingProgram::_compileFragmentShader()
+{
+	struct stat result;
+	if (stat(_fragment.c_str(), &result) == 0)
+		_fragmentModify = result.st_mtime;
+
+	GLuint shader_id = glCreateShader(GL_FRAGMENT_SHADER);
+	_fragmentCode = _getShaderCode(_fragment);
+	const GLchar* source = _fragmentCode.c_str();
+	glShaderSource(shader_id, 1, &source, nullptr);
+	glCompileShader(shader_id);
+	_checkCompilation(shader_id, _fragment);
+	return shader_id;
+}
+
+std::string	ShadingProgram::_getShaderCode(std::string filepath)
 {
 	std::ifstream fileStream(filepath);
 
 	if (fileStream.fail() || !fileStream.good())
 	{
-		std::cerr << "Cannot read shader file" << std::endl;
+		std::cerr << "Cannot read shader file: " << filepath << std::endl;
 	}
 	std::stringstream buf;
 	buf << fileStream.rdbuf();
 	return buf.str();
 }
 
-void	ShadingProgram::CheckCompilation(GLuint id, std::string path)
+void	ShadingProgram::_checkCompilation(GLuint id, std::string path)
 {
 	GLint success = 0;
 	GLint logsize;
@@ -60,7 +103,7 @@ void	ShadingProgram::CheckCompilation(GLuint id, std::string path)
 	}
 }
 
-void	ShadingProgram::CheckLinking(void)
+void	ShadingProgram::_checkLinking()
 {
 	GLint success = 0;
 	GLint logsize;
@@ -78,12 +121,32 @@ void	ShadingProgram::CheckLinking(void)
 	}
 }
 
-void	ShadingProgram::Use(void)
+void	ShadingProgram::Use()
 {
 	glUseProgram(_program);
 }
 
-GLuint	ShadingProgram::ID(void)
+GLuint	ShadingProgram::Uniform(const std::string& name)
 {
-	return _program;
+	if (_uniforms.count(name) == 0)
+		_uniforms[name] = glGetUniformLocation(_program, name.c_str());
+	return _uniforms[name];
+}
+
+void ShadingProgram::Update()
+{
+	bool keepVert = true;
+	bool keepFrag = true;
+
+	struct stat stat_v;
+	if (stat(_vertex.c_str(), &stat_v) == 0)
+		if (stat_v.st_mtime > _vertexModify)
+			keepVert = false;
+
+	struct stat stat_f;
+	if (stat(_fragment.c_str(), &stat_f) == 0)
+		if (stat_f.st_mtime > _fragmentModify)
+			keepFrag = false;
+
+	_recompileProgram(keepVert, keepFrag);
 }

--- a/src/ShadingProgram.cpp
+++ b/src/ShadingProgram.cpp
@@ -21,6 +21,7 @@ void ShadingProgram::_recompileProgram(bool keepVert, bool keepFrag)
 {
 	if (keepVert && keepFrag)
 		return;
+	std::cout << "program changing" << std::endl;
 	if (!keepVert)
 	{
 		glDeleteShader(_vertexShaderID);
@@ -38,6 +39,7 @@ void ShadingProgram::_recompileProgram(bool keepVert, bool keepFrag)
 	glAttachShader(_program, _fragmentShaderID);
 	glLinkProgram(_program);
 	_checkLinking();
+	_getUniforms();
 }
 
 GLuint ShadingProgram::_compileVertexShader()
@@ -119,6 +121,12 @@ void	ShadingProgram::_checkLinking()
 		std::cerr << "Error linking shader program:" << std::endl << log << std::endl;
 		delete[] log;
 	}
+}
+
+void ShadingProgram::_getUniforms()
+{
+	for (auto& p : _uniforms)
+		p.second = glGetUniformLocation(_program, p.first.c_str());
 }
 
 void	ShadingProgram::Use()

--- a/src/ShadingProgram.hpp
+++ b/src/ShadingProgram.hpp
@@ -3,10 +3,15 @@
 #include "util_inc.hpp"
 #include <string>
 #include <map>
+#include <list>
+#include <algorithm>
 #include <sys/stat.h>
 
 class ShadingProgram
 {
+	static std::list<ShadingProgram*> _updateList;
+	bool _shouldUpdate;
+
 	std::string _vertexCode;
 	std::string _fragmentCode;
 	GLuint _program;
@@ -28,10 +33,13 @@ class ShadingProgram
 	void _checkCompilation(GLuint, std::string filepath);
 	void _checkLinking();
 
+	void _update();
+
 public:
-	ShadingProgram(std::string vp, std::string fp);
+	ShadingProgram(std::string vp, std::string fp, bool update=false);
 	~ShadingProgram();
 	void Use();
 	GLuint Uniform(const std::string&);
-	void Update();
+
+	static void UpdateAll();
 };

--- a/src/ShadingProgram.hpp
+++ b/src/ShadingProgram.hpp
@@ -22,6 +22,7 @@ class ShadingProgram
 	void _recompileProgram(bool keepVert, bool keepFrag);
 	GLuint _compileVertexShader();
 	GLuint _compileFragmentShader();
+	void _getUniforms();
 
 	std::string _getShaderCode(std::string filepath);
 	void _checkCompilation(GLuint, std::string filepath);

--- a/src/ShadingProgram.hpp
+++ b/src/ShadingProgram.hpp
@@ -1,19 +1,36 @@
 #pragma once
 
 #include "util_inc.hpp"
+#include <string>
+#include <map>
+#include <sys/stat.h>
 
-class	ShadingProgram
+class ShadingProgram
 {
-private:
-
+	std::string _vertexCode;
+	std::string _fragmentCode;
 	GLuint _program;
+	std::string _vertex;
+	GLuint _vertexShaderID;
+	time_t _vertexModify;
+	std::string _fragment;
+	GLuint _fragmentShaderID;
+	time_t _fragmentModify;
 
-	std::string	GetShaderCode(std::string filepath);
-	void	CheckCompilation(GLuint, std::string filepath);
-	void	CheckLinking(void);
+	std::map<std::string, GLuint> _uniforms;
+
+	void _recompileProgram(bool keepVert, bool keepFrag);
+	GLuint _compileVertexShader();
+	GLuint _compileFragmentShader();
+
+	std::string _getShaderCode(std::string filepath);
+	void _checkCompilation(GLuint, std::string filepath);
+	void _checkLinking();
 
 public:
-	ShadingProgram(std::string vertexPath, std::string fragPath);
-	void	Use(void);
-	GLuint	ID(void);
+	ShadingProgram(std::string vp, std::string fp);
+	~ShadingProgram();
+	void Use();
+	GLuint Uniform(const std::string&);
+	void Update();
 };

--- a/src/SkyBox.cpp
+++ b/src/SkyBox.cpp
@@ -128,6 +128,7 @@ SkyBox::~SkyBox()
 
 void	SkyBox::Render(const CameraData& cam_data)
 {
+	_program->Update();
 	_program->Use();
 	glm::mat4 transform = cam_data.projection * glm::mat4(glm::mat3(cam_data.view));
 	glUniformMatrix4fv(

--- a/src/SkyBox.cpp
+++ b/src/SkyBox.cpp
@@ -103,7 +103,7 @@ void SkyBox::_makeVAO()
 SkyBox::SkyBox(std::string right, std::string left, std::string top,
 			std::string bot, std::string back, std::string front)
 {
-	_program = new ShadingProgram(_vertexPath, _fragPath);
+	_program = new ShadingProgram(_vertexPath, _fragPath, true);
 	_program->Use();
 
 	_loadArrayBuffers();
@@ -128,7 +128,6 @@ SkyBox::~SkyBox()
 
 void	SkyBox::Render(const CameraData& cam_data)
 {
-	_program->Update();
 	_program->Use();
 	glm::mat4 transform = cam_data.projection * glm::mat4(glm::mat3(cam_data.view));
 	glUniformMatrix4fv(

--- a/src/SkyBox.cpp
+++ b/src/SkyBox.cpp
@@ -104,10 +104,7 @@ SkyBox::SkyBox(std::string right, std::string left, std::string top,
 			std::string bot, std::string back, std::string front)
 {
 	_program = new ShadingProgram(_vertexPath, _fragPath);
-	_textureLocationID = glGetUniformLocation(_program->ID(), "tex");
-	glUseProgram(_program->ID());
-
-	_projectionID = glGetUniformLocation(_program->ID(), "projection");
+	_program->Use();
 
 	_loadArrayBuffers();
 
@@ -122,7 +119,7 @@ SkyBox::SkyBox(std::string right, std::string left, std::string top,
 	_makeVAO();
 }
 
-SkyBox::~SkyBox(void)
+SkyBox::~SkyBox()
 {
 	glDeleteTextures(1, &_textureID);
 	glDeleteBuffers(1, &_vertexArrayID);
@@ -134,7 +131,7 @@ void	SkyBox::Render(const CameraData& cam_data)
 	_program->Use();
 	glm::mat4 transform = cam_data.projection * glm::mat4(glm::mat3(cam_data.view));
 	glUniformMatrix4fv(
-		_projectionID,
+		_program->Uniform("projection"),
 		1,
 		GL_FALSE,
 		glm::value_ptr(transform)
@@ -142,7 +139,7 @@ void	SkyBox::Render(const CameraData& cam_data)
 
 	glBindTexture(GL_TEXTURE_CUBE_MAP, _textureID);
 	glActiveTexture(GL_TEXTURE0);
-	glUniform1i(_textureLocationID, 0);
+	glUniform1i(_program->Uniform("tex"), 0);
 	glBindVertexArray(_VAO);
 
 	// save old

--- a/src/SkyBox.hpp
+++ b/src/SkyBox.hpp
@@ -15,8 +15,6 @@ class	SkyBox
 	ShadingProgram *_program;
 	GLuint _vertexArrayID;
 	GLuint _textureID;
-	GLuint _textureLocationID;
-	GLuint _projectionID;
 	GLuint _VAO;
 
 	void _loadArrayBuffers();
@@ -26,6 +24,6 @@ class	SkyBox
 public:
 	SkyBox(std::string right, std::string left, std::string top,
 		   std::string bot, std::string back, std::string front);
-	~SkyBox(void);
+	~SkyBox();
 	void	Render(const CameraData& cam_data);
 };

--- a/src/Text.cpp
+++ b/src/Text.cpp
@@ -16,7 +16,7 @@ Text::Text(std::string message)
 	if (_init)
 		return;
 
-	_program = new ShadingProgram(_vertexPath, _fragPath);
+	_program = new ShadingProgram(_vertexPath, _fragPath, true);
 
 	_square.resize(12);
 	_uv.resize(12);
@@ -123,11 +123,6 @@ void	Text::RenderChar(char c, glm::vec2 topleft, glm::vec2 botright)
 
 void	Text::Render(float aspect)
 {
-	_program->Update();
-
-//	float screenWidth = aspect;
-//	float screenHeight = 1;
-
 	float charWidth = 1 / aspect;
 	float charHeight = 1;
 

--- a/src/Text.cpp
+++ b/src/Text.cpp
@@ -6,7 +6,6 @@ std::vector<float> Text::_uv;
 GLuint Text::_squareID;
 GLuint Text::_UVID;
 GLuint Text::_textureID;
-GLuint Text::_textureLocationID;
 GLuint Text::_VAO;
 bool Text::_init = false;
 
@@ -22,22 +21,21 @@ Text::Text(std::string message)
 	_square.resize(12);
 	_uv.resize(12);
 
-	_textureLocationID = glGetUniformLocation(_program->ID(), "tex");
-	glUseProgram(_program->ID());
+	_program->Use();
 
 	glGenBuffers(1, &_squareID);
 	glBindBuffer(GL_ARRAY_BUFFER, _squareID);
 	glBufferData(GL_ARRAY_BUFFER,
-		     2 * 6 * sizeof(GLfloat),
-		     NULL,
-		     GL_STREAM_DRAW);
+		2 * 6 * sizeof(GLfloat),
+		NULL,
+		GL_STREAM_DRAW);
 
 	glGenBuffers(1, &_UVID);
 	glBindBuffer(GL_ARRAY_BUFFER, _UVID);
 	glBufferData(GL_ARRAY_BUFFER,
-		     12 * sizeof(GLfloat),
-		     NULL,
-		     GL_STREAM_DRAW);
+		12 * sizeof(GLfloat),
+		NULL,
+		GL_STREAM_DRAW);
 
 	Texture textureParser(_fontFile);
 
@@ -45,14 +43,14 @@ Text::Text(std::string message)
 	glGenTextures(1, &_textureID);
 	glBindTexture(GL_TEXTURE_2D, _textureID);
 	glTexImage2D(GL_TEXTURE_2D,
-		     0,
-		     GL_RGBA,
-		     textureParser.Width(),
-		     textureParser.Height(),
-		     0,
-		     GL_RGBA,
-		     GL_UNSIGNED_BYTE,
-		     textureParser.Data());
+		0,
+		GL_RGBA,
+		textureParser.Width(),
+		textureParser.Height(),
+		0,
+		GL_RGBA,
+		GL_UNSIGNED_BYTE,
+		textureParser.Data());
 
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
@@ -60,7 +58,7 @@ Text::Text(std::string message)
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	glGenerateMipmap(GL_TEXTURE_2D);
 	glActiveTexture(GL_TEXTURE0);
-	glUniform1i(_textureLocationID, 0);
+	glUniform1i(_program->Uniform("tex"), 0);
 
 	glGenVertexArrays(1, &_VAO);
 
@@ -94,26 +92,26 @@ void	Text::RenderChar(char c, glm::vec2 topleft, glm::vec2 botright)
 
 	glBindBuffer(GL_ARRAY_BUFFER, _squareID);
 	glBufferData(GL_ARRAY_BUFFER,
-			     12  * sizeof(GLfloat),
-			     NULL,
-			     GL_STREAM_DRAW);
+		12  * sizeof(GLfloat),
+		NULL,
+		GL_STREAM_DRAW);
 	glBufferSubData(GL_ARRAY_BUFFER,
-				0,
-				12 * sizeof(GLfloat),
-				&_square[0]);
+		0,
+		12 * sizeof(GLfloat),
+		&_square[0]);
 
 	glEnableVertexAttribArray(0);
 	glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, 0);
 
 	glBindBuffer(GL_ARRAY_BUFFER, _UVID);
 	glBufferData(GL_ARRAY_BUFFER,
-			     12 * sizeof(GLfloat),
-			     NULL,
-			     GL_STREAM_DRAW);
+		12 * sizeof(GLfloat),
+		NULL,
+		GL_STREAM_DRAW);
 	glBufferSubData(GL_ARRAY_BUFFER,
-				0,
-				12 * sizeof(GLfloat),
-				&_uv[0]);
+		0,
+		12 * sizeof(GLfloat),
+		&_uv[0]);
 	glEnableVertexAttribArray(1);
 	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, 0);
 
@@ -125,7 +123,7 @@ void	Text::RenderChar(char c, glm::vec2 topleft, glm::vec2 botright)
 
 void	Text::Render(float aspect)
 {
-
+	_program->Update();
 
 //	float screenWidth = aspect;
 //	float screenHeight = 1;
@@ -152,8 +150,8 @@ void	Text::Render(float aspect)
 	glDisable(GL_DEPTH_TEST);
 
 	glBindTexture(GL_TEXTURE_2D, _textureID);
-    glActiveTexture(GL_TEXTURE0);
-    glUniform1i(_textureLocationID, 0);
+	glActiveTexture(GL_TEXTURE0);
+	glUniform1i(_program->Uniform("tex"), 0);
 
 	glBindVertexArray(_VAO);
 	for (size_t i = 0; i < _message.length(); i++)
@@ -163,12 +161,11 @@ void	Text::Render(float aspect)
 		float xCenter =	distFromCenter * charWidth * 0.8;
 
 		RenderChar(_message[i],
-			   glm::vec2(xCenter - charWidth / 2, charHeight / 2),
-			   glm::vec2(xCenter + charWidth / 2, -charHeight / 2));
+			glm::vec2(xCenter - charWidth / 2, charHeight / 2),
+			glm::vec2(xCenter + charWidth / 2, -charHeight / 2));
 	}
 	glBindVertexArray(0);
 
 	glDisable(GL_BLEND);
 	glEnable(GL_DEPTH_TEST);
-
 }

--- a/src/Text.hpp
+++ b/src/Text.hpp
@@ -21,7 +21,6 @@ private:
 	static GLuint _squareID;
 	static GLuint _UVID;
 	static GLuint _textureID;
-	static GLuint _textureLocationID;
 	static GLuint _VAO;
 
 	static bool _init;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "ShaderObj.hpp"
 #include "Light.hpp"
 #include "Transparency.hpp"
+#include "ShadingProgram.hpp"
 
 int	main(void)
 {
@@ -34,11 +35,20 @@ int	main(void)
 
 	Light l2(glm::vec3(0, 10, 0), glm::vec3(0.4, 0.9, 0.6));
 
+	int lastSecond = 0;
+
 	while (!window.ShouldClose())
 	{
 		if ((err = glGetError()) != GL_NO_ERROR)
 			std::cerr << err << std::endl;
 		clock.Step();
+
+		if (int(clock.Total()) > lastSecond)
+		{
+			lastSecond = clock.Total();
+			ShadingProgram::UpdateAll();
+		}
+
 		window.Clear();
 		cam.Update(clock.Delta());
 		scene.Render(cam.GetCameraData());

--- a/src/shaders/obj.frag
+++ b/src/shaders/obj.frag
@@ -11,8 +11,6 @@ out vec3 color;
 
 void	main()
 {
-	float modify = max(dot(normalize(normal_v), dir_v), 0.07);
-	modify /= max(dist_v, 10.0);
-	modify = (modify / (modify + 0.02));
+	float modify = abs(dot(normalize(dir_v), normalize(normal_v)));
 	color = texture(tex, uv_v).rgb * modify;
 }

--- a/src/shaders/obj.vert
+++ b/src/shaders/obj.vert
@@ -17,7 +17,7 @@ void	main()
 {
     gl_Position = worldToScreen * transform * vec4(vertex, 1);
     normal_v = normal;
-    dir_v = vec3(vertex) - campos;
+    dir_v = vec3(transform * vec4(vertex, 1)) - campos;
     dist_v = length(dir_v);
     dir_v = normalize(dir_v);
     uv_v = uv;


### PR DESCRIPTION
changed shading program so that it can be auto loaded by calling `ShaderObject::UpdateAll()`

you can pass 3rd argument as false to not have this functionality.

ShadingProgram now has a `Uniform()` method that will return the OpenGL uniformID for the given string. There is no need to use `glGetUniformLocation()`