### PR TITLE
Ao and soft shadows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,11 @@ ShaderObj \
 Light \
 Transparency
 
-SRC_DIR = src
 OBJ_DIR = obj
 
-SRC = $(addsuffix .cpp, $(addprefix src/, $(LIST)))
+VPATH = src
+
+SRC = $(addsuffix .cpp, $(LIST))
 OBJ = $(addsuffix .o, $(addprefix $(OBJ_DIR)/, $(LIST)))
 DEP = $(OBJ:%.o=%.d)
 
@@ -42,7 +43,7 @@ $(OBJ_DIR):
 
 -include $(DEP)
 
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
+$(OBJ_DIR)/%.o: %.cpp
 	@printf "\e[34;1mCompiling: \e[0m%s\n" $<
 	@clang++ $(CPPFLAGS) -MMD -c $< -o $@
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# shader-pixel
+Integrating objects rendered in the fragment shader with a polygon scene
+In C++ and Opengl
+
+# Team
+Theo Walton
+Logan Kaser

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@ int	main(void)
 		"assets/textures/skybox/back.png"
 	);
 	ObjRender::Init();
-	ShaderObj shader("src/shaders/marble.frag");
+	ShaderObj shader("src/shaders/mandelbox.frag");
 	Scene scene;
 
 	Light l2(glm::vec3(0, 10, 0), glm::vec3(0.4, 0.9, 0.6));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,7 +14,7 @@ int	main(void)
 {
 	GLenum err;
 
-	Window window(1280, 720, "ft_vox");
+	Window window(1280, 720, "shader_pixel");
 	glClearColor(0.2, 0.25, 0.3, 1);
 
 	FPSDisplay fps;
@@ -29,7 +29,7 @@ int	main(void)
 		"assets/textures/skybox/back.png"
 	);
 	ObjRender::Init();
-	ShaderObj shader_object("src/shaders/marble.frag");
+	ShaderObj shader("src/shaders/marble.frag");
 	Scene scene;
 
 	Light l2(glm::vec3(0, 10, 0), glm::vec3(0.4, 0.9, 0.6));
@@ -53,8 +53,11 @@ int	main(void)
 		scene.Render(cam.GetCameraData());
 		sky.Render(cam.GetCameraData());
 
-		shader_object.Render(cam.GetCameraData(),
-			glm::translate(glm::mat4(1), glm::vec3(3, 2, 3)), clock.Total());
+		glm::mat4 tr = glm::mat4(2);
+		tr[3][3] = 1;
+
+		shader.Render(cam.GetCameraData(),
+			glm::translate(glm::mat4(1), glm::vec3(0, 3, 0)), clock.Total());
 
 		Transparency::RenderAll();
 		fps.Render(window);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,8 +29,7 @@ int	main(void)
 		"assets/textures/skybox/back.png"
 	);
 	ObjRender::Init();
-	ShaderObj mandelbox("src/shaders/mandelbox.frag");
-	ShaderObj sphere("src/shaders/sphere.frag");
+	ShaderObj shader_object("src/shaders/marble.frag");
 	Scene scene;
 
 	Light l2(glm::vec3(0, 10, 0), glm::vec3(0.4, 0.9, 0.6));
@@ -54,14 +53,8 @@ int	main(void)
 		scene.Render(cam.GetCameraData());
 		sky.Render(cam.GetCameraData());
 
-		sphere.Render(cam.GetCameraData(),
+		shader_object.Render(cam.GetCameraData(),
 			glm::translate(glm::mat4(1), glm::vec3(3, 2, 3)), clock.Total());
-
-		mandelbox.Render(cam.GetCameraData(),
-			glm::translate(glm::mat4(1), glm::vec3(0, 3, 0)), clock.Total());
-
-		sphere.Render(cam.GetCameraData(),
-			glm::translate(glm::mat4(1), glm::vec3(0, 2, 3)), clock.Total());
 
 		Transparency::RenderAll();
 		fps.Render(window);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@ int	main(void)
 		"assets/textures/skybox/back.png"
 	);
 	ObjRender::Init();
-	ShaderObj shader("src/shaders/mandelbox.frag");
+	ShaderObj shader("src/shaders/ifs.frag");
 	Scene scene;
 
 	Light l2(glm::vec3(0, 10, 0), glm::vec3(0.4, 0.9, 0.6));

--- a/src/shaders/ifs.frag
+++ b/src/shaders/ifs.frag
@@ -1,0 +1,150 @@
+#version 410 core
+
+#define MAX_LIGHTS 100
+
+in vec3 ray_tp;
+in vec3 ray_tv;
+
+uniform mat4 worldToScreen;
+uniform mat4 transform;
+
+uniform vec3 lightPos[MAX_LIGHTS];
+uniform vec3 lightColor[MAX_LIGHTS];
+uniform int lightNum;
+
+uniform float time;
+
+out vec4 color;
+
+const int MARCH_MAX = 255;
+const float MARCH_MIN_DIST = 0.0f;
+const float MARCH_MAX_DIST = 50.0f;
+const float MARCH_STEP = 0.1f;
+const float EPSILON = 0.001f;
+const float PI = 3.14159;
+
+vec2 fold(vec2 p, float ang){
+    vec2 n = vec2(cos(-ang), sin(-ang));
+    p -= 2.0 * min(0.0, dot(p,n)) * n;
+    return p;
+}
+
+vec3 tri_fold(vec3 pt) {
+    pt.xy = fold(pt.xy, PI / 3.0 - cos(time) / 10.0);
+    pt.xy = fold(pt.xy, -PI / 3.0);
+    pt.yz = fold(pt.yz, -PI / 6.0 + sin(time) / 2.0);
+    pt.yz = fold(pt.yz, PI / 6.0);
+    return pt;
+}
+vec3 tri_curve(vec3 pt) {
+    for (int i = 0; i < 8; i++){
+        pt *= 2.0;
+        pt.x -= 2.6;
+        pt = tri_fold(pt);
+    }
+    return pt;
+}
+float ifs(vec3 p){
+    p *= 0.75;
+    p.x += 1.5;
+    p = tri_curve(p);
+    return (length(p * 0.004) - 0.01);
+}
+
+// Distance field representing our scene.
+float scene(vec3 p) {
+    return ifs(p * 10) / 10;
+}
+
+float ray_march(vec3 ro, vec3 rv) {
+    float depth = MARCH_MIN_DIST;
+    for (int i = 0; i < MARCH_MAX; ++i)
+    {
+        float min_distance = scene(ro + rv * depth);
+        depth += min_distance;
+        if (min_distance < EPSILON || depth >= MARCH_MAX_DIST) {
+            break;
+        }
+    }
+    return min(depth, MARCH_MAX_DIST);
+}
+
+/* Lighting */
+
+// 1 for less accurate but faster normal, 0 for accurate but slower version.
+
+#if 1
+
+vec3 get_normal(vec3 p) {
+    float ref = scene(p);
+    return normalize(vec3(
+        scene(vec3(p.x + EPSILON, p.y, p.z)) - ref,
+        scene(vec3(p.x, p.y + EPSILON, p.z)) - ref,
+        scene(vec3(p.x, p.y, p.z + EPSILON)) - ref
+    ));
+}
+
+#else
+
+vec3 get_normal(vec3 p) {
+    return normalize(vec3(
+        scene(vec3(p.x + EPSILON, p.y, p.z)) - scene(vec3(p.x - EPSILON, p.y, p.z)),
+        scene(vec3(p.x, p.y + EPSILON, p.z)) - scene(vec3(p.x, p.y - EPSILON, p.z)),
+        scene(vec3(p.x, p.y, p.z  + EPSILON)) - scene(vec3(p.x, p.y, p.z - EPSILON))
+    ));
+}
+
+#endif
+
+float ambient_occulsion(vec3 normal, vec3 p)
+{
+    float x = 0.0;
+    x += 0.1 - scene(p + normal * 0.1);
+    x += 0.3 - scene(p + normal * 0.3);
+    x += 0.5 - scene(p + normal * 0.5);
+    return 1.0 - x;
+}
+
+float diffuse(vec3 normal, vec3 light_normal)
+{
+    return dot(normal, light_normal);
+}
+
+float soft_shadow(vec3 intersect, vec3 light_normal, float softness)
+{
+    float res = 1.0;
+    for (float depth = 0.01; depth < 20;)
+    {
+        float min_distance = scene(intersect + light_normal * depth);
+        if (min_distance < 0.001)
+            return 0.0;
+        res = min(res, softness * min_distance / depth);
+        depth += min_distance;
+    }
+    return res;
+}
+
+vec3 shader(vec3 ro, vec3 rv) {
+    float dist = ray_march(ro, rv);
+    if (dist > MARCH_MAX_DIST - EPSILON)
+        discard;
+    vec3 intersect = ro + rv * dist;
+    vec3 normal = get_normal(intersect);
+
+    vec3 c = vec3(1.0);
+
+    c *= max(diffuse(normal, vec3(0.0, 1.0, 0.0)), 0.2);
+    //c *= ambient_occulsion(normal, intersect);
+    //c *= soft_shadow(intersect, vec3(0.0, 1.0, 0.0), 2.0);
+
+    color = vec4(c, 1.0);
+
+    return intersect;
+}
+
+void main()
+{
+    vec3 intersect = shader(ray_tp, normalize(ray_tv));
+    //vec4 screenPoint = worldToScreen * transform * vec4(intersect, 1);
+    //gl_FragDepth = (screenPoint.z / screenPoint.w + 1) / 2;
+}

--- a/src/shaders/mandelbox.frag
+++ b/src/shaders/mandelbox.frag
@@ -22,7 +22,7 @@ const float MARCH_MAX_DIST = 50.0f;
 const float EPSILON = 0.001f;
 
 // Mandelbox
-const float ITERS = 8;
+const float ITERS = 6;
 const float SCALE = 2.7f;
 const float MR2 = 0.25f;
 
@@ -44,18 +44,10 @@ float mandelbox(vec3 position){
   return (length(p.xyz) - C1) / p.w - C2;
 }
 
+// Distance field representing our scene.
 float scene(vec3 p) {
 	// Scaled mandelbox by 0.1
 	return mandelbox(p * 10) / 10;
-}
-
-vec3 get_normal(vec3 p) {
-	float ref = scene(p);
-	return normalize(vec3(
-		scene(vec3(p.x + EPSILON, p.y, p.z)) - ref,
-		scene(vec3(p.x, p.y + EPSILON, p.z)) - ref,
-		scene(vec3(p.x, p.y, p.z + EPSILON)) - ref
-	));
 }
 
 float ray_march(vec3 rp, vec3 rv) {
@@ -64,7 +56,7 @@ float ray_march(vec3 rp, vec3 rv) {
 	{
 		float min_distance = scene(rp + rv * depth);
 		if (min_distance < EPSILON) {
-			color = vec4(1.0, 0.5, 0.5, 1.0);
+			color = vec4(0.6, 1.0, 0.6, 1.0);
 			break;
 		}
 		depth += min_distance;
@@ -77,21 +69,60 @@ float ray_march(vec3 rp, vec3 rv) {
 	return depth;
 }
 
+/* Lighting */
+
+// 1 for less accurate but faster normal, 0 for accurate but slower version.
+
+#if 1
+
+vec3 get_normal(vec3 p) {
+	float ref = scene(p);
+	return normalize(vec3(
+		scene(vec3(p.x + EPSILON, p.y, p.z)) - ref,
+		scene(vec3(p.x, p.y + EPSILON, p.z)) - ref,
+		scene(vec3(p.x, p.y, p.z + EPSILON)) - ref
+	));
+}
+
+#else
+
+vec3 get_normal(vec3 p) {
+    return normalize(vec3(
+        scene(vec3(p.x + EPSILON, p.y, p.z)) - scene(vec3(p.x - EPSILON, p.y, p.z)),
+        scene(vec3(p.x, p.y + EPSILON, p.z)) - scene(vec3(p.x, p.y - EPSILON, p.z)),
+        scene(vec3(p.x, p.y, p.z  + EPSILON)) - scene(vec3(p.x, p.y, p.z - EPSILON))
+    ));
+}
+
+#endif
+
+float ambient_occulsion(vec3 normal, vec3 p)
+{
+	float x = 0.0;
+	x += 0.1 -  scene(p + normal * 0.1);
+	x += 0.3 -  scene(p + normal * 0.3);
+	x += 0.5 -  scene(p + normal * 0.5);
+	return 1.0 - x;
+}
+
+float diffuse(vec3 normal, vec3 ray_dir)
+{
+	return max(dot(normal, -ray_dir), 0.1);
+}
+
 vec3 shader(vec3 rp, vec3 rv) {
 	float dist = ray_march(rp, rv);
 	if (dist > MARCH_MAX_DIST - EPSILON)
 		discard;
 	vec3 intersect = rp + rv * dist;
-	vec3 normal = normalize(intersect);
-	vec3 col = vec3(0);
+	vec3 normal = get_normal(intersect);
 
-	for (int i = 0; i < lightNum; i++)
-	{
-		vec3 lp = lightPos[i];
-		col += lightColor[0] * dot(normalize(lp - intersect), normal) * 
-			normalize(abs(lp));
-	}
-	color = vec4(col / (col + vec3(1)), 1);
+	// Various lighting effects.
+	float light = 1.0;
+	light *= diffuse(normal, rv);
+	light *= ambient_occulsion(normal, intersect);
+
+	color.xyz *= light; // Apply Light coefficent.
 
 	return intersect;
 }

--- a/src/shaders/mandelbox.frag
+++ b/src/shaders/mandelbox.frag
@@ -23,7 +23,7 @@ const float EPSILON = 0.001f;
 
 const vec4 materials[2] = vec4[](
     vec4(0.0), // Null Color
-    vec4(1.0, 0.0, 0.1, 1.0) // Gold
+    vec4(1.0, 0.0, 0.1, 1.0) // Maroon
 );
 
 // Mandelbox

--- a/src/shaders/mandelbox.frag
+++ b/src/shaders/mandelbox.frag
@@ -14,12 +14,17 @@ uniform int lightNum;
 
 uniform float time;
 
-out vec4 color;
+out vec4 frag_color;
 
 const int MARCH_MAX = 255;
 const float MARCH_MIN_DIST = 0.0f;
-const float MARCH_MAX_DIST = 50.0f;
+const float MARCH_MAX_DIST = 20.0f;
 const float EPSILON = 0.001f;
+
+const vec4 materials[2] = vec4[](
+    vec4(0.0), // Null Color
+    vec4(1.0, 0.0, 0.1, 1.0) // Gold
+);
 
 // Mandelbox
 const float ITERS = 6;
@@ -29,34 +34,34 @@ const float MR2 = 0.25f;
 const vec4 scalevec = vec4(SCALE, SCALE, SCALE, abs(SCALE)) / MR2;
 const float C1 = abs(SCALE - 1.0), C2 = pow(abs(SCALE), float(1 - ITERS));
 
-float mandelbox(vec3 position){
-  vec4 p = vec4(position.xyz, 1.0), p0 = vec4(position.xyz, 1.0);
-  for (int i=0; i < ITERS; i++) {
-    p.xyz = clamp(p.xyz, -1.0, 1.0) * 2.0 - p.xyz;
-    float r2 = dot(p.xyz, p.xyz);
-	p.xyzw *= clamp(max(MR2 / r2, MR2), 0.0, 1.0);
-    p.xyzw = p * scalevec + p0;
-  }
-  return (length(p.xyz) - C1) / p.w - C2;
+float mandelbox(vec3 position, out int object_id) {
+    object_id = 1;
+    vec4 p = vec4(position.xyz, 1.0), p0 = vec4(position.xyz, 1.0);
+    for (int i = 0; i < ITERS; i++) {
+        p.xyz = clamp(p.xyz, -1.0, 1.0) * 2.0 - p.xyz;
+        float r2 = dot(p.xyz, p.xyz);
+        p.xyzw *= clamp(max(MR2 / r2, MR2), 0.0, 1.0);
+        p.xyzw = p * scalevec + p0;
+    }
+    return (length(p.xyz) - C1) / p.w - C2;
 }
 
-// Distance field representing our scene.
-float scene(vec3 p) {
-	// Scaled mandelbox by 0.1
-	return mandelbox(p * 10) / 10;
+// Distance field representing the scene.
+float scene(vec3 p, out int object_id) {
+    return mandelbox(p * 10.0, object_id) / 10.0;
 }
 
-float ray_march(vec3 rp, vec3 rv) {
-	float depth = MARCH_MIN_DIST;
-	for (int i = 0; i < MARCH_MAX; ++i)
-	{
-		float min_distance = scene(rp + rv * depth);
-		depth += min_distance;
-		if (min_distance < EPSILON || depth >= MARCH_MAX_DIST) {
-			break;
-		}
-	}
-	return min(depth, MARCH_MAX_DIST);
+float ray_march(vec3 ro, vec3 rv, out int object_id) {
+    float depth = MARCH_MIN_DIST;
+    for (int i = 0; i < MARCH_MAX; ++i)
+    {
+        float min_distance = scene(ro + rv * depth, object_id);
+        depth += min_distance;
+        if (min_distance < EPSILON || depth >= MARCH_MAX_DIST) {
+            break;
+        }
+    }
+    return min(depth, MARCH_MAX_DIST);
 }
 
 /* Lighting */
@@ -66,75 +71,101 @@ float ray_march(vec3 rp, vec3 rv) {
 #if 1
 
 vec3 get_normal(vec3 p) {
-	float ref = scene(p);
-	return normalize(vec3(
-		scene(vec3(p.x + EPSILON, p.y, p.z)) - ref,
-		scene(vec3(p.x, p.y + EPSILON, p.z)) - ref,
-		scene(vec3(p.x, p.y, p.z + EPSILON)) - ref
-	));
+    int _;
+    float ref = scene(p, _);
+    return normalize(vec3(
+        scene(vec3(p.x + EPSILON, p.y, p.z), _) - ref,
+        scene(vec3(p.x, p.y + EPSILON, p.z), _) - ref,
+        scene(vec3(p.x, p.y, p.z + EPSILON), _) - ref
+    ));
 }
 
 #else
 
 vec3 get_normal(vec3 p) {
+    int _;
     return normalize(vec3(
-        scene(vec3(p.x + EPSILON, p.y, p.z)) - scene(vec3(p.x - EPSILON, p.y, p.z)),
-        scene(vec3(p.x, p.y + EPSILON, p.z)) - scene(vec3(p.x, p.y - EPSILON, p.z)),
-        scene(vec3(p.x, p.y, p.z  + EPSILON)) - scene(vec3(p.x, p.y, p.z - EPSILON))
+        scene(vec3(p.x + EPSILON, p.y, p.z), _) - scene(vec3(p.x - EPSILON, p.y, p.z), _),
+        scene(vec3(p.x, p.y + EPSILON, p.z), _) - scene(vec3(p.x, p.y - EPSILON, p.z), _),
+        scene(vec3(p.x, p.y, p.z  + EPSILON), _) - scene(vec3(p.x, p.y, p.z - EPSILON), _)
     ));
 }
 
 #endif
 
-float ambient_occulsion(vec3 normal, vec3 p)
+float ambient_occulsion(vec3 normal, vec3 pos)
 {
-	float x = 0.0;
-	x += 0.1 - scene(p + normal * 0.1);
-	x += 0.3 - scene(p + normal * 0.3);
-	x += 0.5 - scene(p + normal * 0.5);
-	return 1.0 - x;
+    int _;
+    float x = 0.0;
+    x += 0.1 - scene(pos + normal * 0.1, _);
+    x += 0.3 - scene(pos + normal * 0.3, _);
+    x += 0.5 - scene(pos + normal * 0.5, _);
+    return 1.0 - x;
 }
 
-float diffuse(vec3 normal, vec3 light_normal)
+vec3 phong(vec3 normal, vec3 material_color, vec3 cam_dir, vec3 light_normal, vec3 light_color, float light_strength)
 {
-	return dot(normal, light_normal);
+    float distance = length(light_normal);
+    light_normal = normalize(light_normal);
+
+    float diffuse = clamp(dot(normal, light_normal), 0.0, 1.0);
+
+    vec3 reflected_light_dir = normalize(reflect(light_normal, normal));
+
+    float specular = pow(clamp(dot(reflected_light_dir, cam_dir), 0.0, 1.0), 10.0);
+
+    vec3 diffuse_color = material_color * max(diffuse, 0.02);
+    vec3 specular_color = light_color * specular;
+
+    distance *= distance;
+    return (diffuse_color + specular_color) * light_strength / distance;
 }
 
-float soft_shadow(vec3 intersect, vec3 light_normal, float softness)
+float soft_shadow(vec3 pos, vec3 light_normal, float softness)
 {
     float res = 1.0;
-    for (float depth = 0.01; depth < 20;)
+    int _;
+    light_normal = normalize(light_normal);
+    for (float depth = EPSILON * 2.0; depth < 20.0;)
     {
-        float min_distance = scene(intersect + light_normal * depth);
+        float min_distance = scene(pos + light_normal * depth, _);
         if (min_distance < 0.001)
-            return 0.0;
+            return 0.02;
         res = min(res, softness * min_distance / depth);
         depth += min_distance;
     }
     return res;
 }
 
-vec3 shader(vec3 rp, vec3 rv) {
-	float dist = ray_march(rp, rv);
-	if (dist > MARCH_MAX_DIST - EPSILON)
-		discard;
-	vec3 intersect = rp + rv * dist;
-	vec3 normal = get_normal(intersect);
+void shader(vec3 ro, vec3 rv) {
 
-	vec3 c = vec3(1.0);
+    int object_id;
+    float dist = ray_march(ro, rv, object_id);
+    if (dist > MARCH_MAX_DIST - EPSILON)
+        discard;
+    vec3 pos = ro + rv * dist;
 
-	c *= max(diffuse(normal, vec3(0.0, 1.0, 0.0)), 0.2);
-	c *= ambient_occulsion(normal, intersect);
-	c *= soft_shadow(intersect, vec3(0.0, 1.0, 0.0), 2.0);
+    vec3 normal = get_normal(pos);
 
-	color = vec4(c, 1.0);
+    vec4 object_color = materials[object_id];
 
-	return intersect;
+    vec3 light_normal = vec3(0.0, 5.0, 0.0) - pos; 
+
+    vec3 color = phong(
+        normal, // object normal
+        object_color.xyz,
+        rv, // camera direction
+        light_normal, // light normal
+        vec3(1.0, 1.0, 0.8), // light Color
+        40.0 // Light strength
+    );
+
+    color *= ambient_occulsion(normal, pos);
+    //color *= soft_shadow(pos, light_normal, 4.0);
+    frag_color = vec4(pow(color, vec3(0.4545)), object_color.w);
 }
 
 void main()
 {
-	vec3 intersect = shader(ray_tp, normalize(ray_tv));
-	//vec4 screenPoint = worldToScreen * transform * vec4(intersect, 1);
-	//gl_FragDepth = (screenPoint.z / screenPoint.w + 1) / 2;
+    shader(ray_tp, normalize(ray_tv));
 }

--- a/src/shaders/mandelbulb.frag
+++ b/src/shaders/mandelbulb.frag
@@ -14,31 +14,36 @@ uniform int lightNum;
 
 uniform float time;
 
-out vec4 color;
+out vec4 frag_color;
 
 const int MARCH_MAX = 255;
 const float MARCH_MIN_DIST = 0.0f;
-const float MARCH_MAX_DIST = 50.0f;
+const float MARCH_MAX_DIST = 10.0f;
 const float EPSILON = 0.001f;
 
-float mandelbulb(vec3 p)
+const vec4 materials[5] = vec4[](
+    vec4(0.0), // Null Color
+    vec4(0.1, 0.1, 0.1, 1.0), // Grey
+    vec4(0.6, 0.6, 0.6, 1.0), // Light grey
+    vec4(0.0, 1.0, 0.6, 1.0),
+    vec4(0.0, 0.1, 1.0, 1.0)
+);
+
+float mandelbulb(vec3 p, out int object_id)
 {
     vec3 w = p;
     float m = dot(w,w);
+    float dz = 1.0;
 
-    //vec4 trap = vec4(abs(w),m);
-	float dz = 1.0;
-    
-    
-	for(int i=0; i < 4; i++ )
+    for (int i = 0; i < 4; i++)
     {
         float m2 = m*m;
         float m4 = m2*m2;
-		dz = 8.0 * sqrt(m4 * m2 * m) * dz + 1.0;
+        dz = 8.0 * sqrt(m4 * m2 * m) * dz + 1.0;
 
-        float x = w.x; float x2 = x*x; float x4 = x2*x2;
-        float y = w.y; float y2 = y*y; float y4 = y2*y2;
-        float z = w.z; float z2 = z*z; float z4 = z2*z2;
+        float x = w.x; float x2 = x * x; float x4 = x2 * x2;
+        float y = w.y; float y2 = y * y; float y4 = y2 * y2;
+        float z = w.z; float z2 = z * z; float z4 = z2 * z2;
 
         float k3 = x2 + z2;
         float k2 = inversesqrt(k3 * k3 * k3 * k3 * k3 * k3 * k3);
@@ -48,33 +53,32 @@ float mandelbulb(vec3 p)
         w.x = p.x +  64.0 * x * y * z * (x2-z2) * k4 * (x4 - 6.0 * x2 * z2 + z4) * k1 * k2;
         w.y = p.y + -16.0 * y2 * k3 * k4 * k4 + k1 * k1;
         w.z = p.z +  -8.0 * y * k4 * (x4 * x4 - 28.0 * x4 * x2 * z2 + 70.0 * x4 * z4 - 28.0 * x2 * z2 * z4 + z4 * z4) * k1 * k2;
-        //trap = min(trap, vec4(abs(w), m));
 
-        m = dot(w,w);
-		if (m > 256.0)
+        m = dot(w, w);
+        if (m > 256.0)
             break;
     }
+    object_id = 1 + int(log(m)) % 4;
 
     return 0.25 * log(m) * sqrt(m) / dz;
 }
 
-float scene(vec3 p) {
-	// Scaled mandelbox by 0.1
-	return mandelbulb(p * 2.0) / 2.0;
+// Distance field representing the scene.
+float scene(vec3 p, out int object_id) {
+    return mandelbulb(p * 2.0, object_id) / 2.0;
 }
 
-
-float ray_march(vec3 rp, vec3 rv) {
-	float depth = MARCH_MIN_DIST;
-	for (int i = 0; i < MARCH_MAX; ++i)
-	{
-		float min_distance = scene(rp + rv * depth);
-		depth += min_distance;
-		if (min_distance < EPSILON || depth >= MARCH_MAX_DIST) {
-			break;
-		}
-	}
-	return min(depth, MARCH_MAX_DIST);
+float ray_march(vec3 ro, vec3 rv, out int object_id) {
+    float depth = MARCH_MIN_DIST;
+    for (int i = 0; i < MARCH_MAX; ++i)
+    {
+        float min_distance = scene(ro + rv * depth, object_id);
+        depth += min_distance;
+        if (min_distance < EPSILON || depth >= MARCH_MAX_DIST) {
+            break;
+        }
+    }
+    return min(depth, MARCH_MAX_DIST);
 }
 
 /* Lighting */
@@ -84,75 +88,101 @@ float ray_march(vec3 rp, vec3 rv) {
 #if 1
 
 vec3 get_normal(vec3 p) {
-	float ref = scene(p);
-	return normalize(vec3(
-		scene(vec3(p.x + EPSILON, p.y, p.z)) - ref,
-		scene(vec3(p.x, p.y + EPSILON, p.z)) - ref,
-		scene(vec3(p.x, p.y, p.z + EPSILON)) - ref
-	));
+    int _;
+    float ref = scene(p, _);
+    return normalize(vec3(
+        scene(vec3(p.x + EPSILON, p.y, p.z), _) - ref,
+        scene(vec3(p.x, p.y + EPSILON, p.z), _) - ref,
+        scene(vec3(p.x, p.y, p.z + EPSILON), _) - ref
+    ));
 }
 
 #else
 
 vec3 get_normal(vec3 p) {
+    int _;
     return normalize(vec3(
-        scene(vec3(p.x + EPSILON, p.y, p.z)) - scene(vec3(p.x - EPSILON, p.y, p.z)),
-        scene(vec3(p.x, p.y + EPSILON, p.z)) - scene(vec3(p.x, p.y - EPSILON, p.z)),
-        scene(vec3(p.x, p.y, p.z  + EPSILON)) - scene(vec3(p.x, p.y, p.z - EPSILON))
+        scene(vec3(p.x + EPSILON, p.y, p.z), _) - scene(vec3(p.x - EPSILON, p.y, p.z), _),
+        scene(vec3(p.x, p.y + EPSILON, p.z), _) - scene(vec3(p.x, p.y - EPSILON, p.z), _),
+        scene(vec3(p.x, p.y, p.z  + EPSILON), _) - scene(vec3(p.x, p.y, p.z - EPSILON), _)
     ));
 }
 
 #endif
 
-float ambient_occulsion(vec3 normal, vec3 p)
+float ambient_occulsion(vec3 normal, vec3 pos)
 {
-	float x = 0.0;
-	x += 0.1 - scene(p + normal * 0.1);
-	x += 0.3 - scene(p + normal * 0.3);
-	x += 0.5 - scene(p + normal * 0.5);
-	return 1.0 - x;
+    int _;
+    float x = 0.0;
+    x += 0.1 - scene(pos + normal * 0.1, _);
+    x += 0.3 - scene(pos + normal * 0.3, _);
+    x += 0.5 - scene(pos + normal * 0.5, _);
+    return 1.0 - x;
 }
 
-float diffuse(vec3 normal, vec3 ray_dir)
+vec3 phong(vec3 normal, vec3 material_color, vec3 cam_dir, vec3 light_normal, vec3 light_color, float light_strength)
 {
-	return dot(normal, -ray_dir);
+    float distance = length(light_normal);
+    light_normal = normalize(light_normal);
+
+    float diffuse = clamp(dot(normal, light_normal), 0.0, 1.0);
+
+    vec3 reflected_light_dir = normalize(reflect(light_normal, normal));
+
+    float specular = pow(clamp(dot(reflected_light_dir, cam_dir), 0.0, 1.0), 10.0);
+
+    vec3 diffuse_color = material_color * max(diffuse, 0.02);
+    vec3 specular_color = light_color * specular;
+
+    distance *= distance;
+    return (diffuse_color + specular_color) * light_strength / distance;
 }
 
-float soft_shadow(vec3 intersect, vec3 light_normal, float softness)
+float soft_shadow(vec3 pos, vec3 light_normal, float softness)
 {
     float res = 1.0;
-    for (float depth = MARCH_MIN_DIST; depth < 20;)
+    int _;
+    light_normal = normalize(light_normal);
+    for (float depth = EPSILON * 2.0; depth < 20.0;)
     {
-        float min_distance = scene(intersect + light_normal * depth);
+        float min_distance = scene(pos + light_normal * depth, _);
         if (min_distance < 0.001)
-            return 0.0;
+            return 0.02;
         res = min(res, softness * min_distance / depth);
         depth += min_distance;
     }
     return res;
 }
 
-vec3 shader(vec3 rp, vec3 rv) {
-	float dist = ray_march(rp, rv);
-	if (dist > MARCH_MAX_DIST - EPSILON)
-		discard;
-	vec3 intersect = rp + rv * dist;
-	vec3 normal = get_normal(intersect);
+void shader(vec3 ro, vec3 rv) {
 
-	vec3 c = vec3(1.0);
+    int object_id;
+    float dist = ray_march(ro, rv, object_id);
+    if (dist > MARCH_MAX_DIST - EPSILON)
+        discard;
+    vec3 pos = ro + rv * dist;
 
-	c *= max(diffuse(normal, rv), 0.2);
-	//c *= ambient_occulsion(normal, intersect);
-	c *= soft_shadow(intersect, vec3(0.0, 1.0, 0.0), 2.0);
+    vec3 normal = get_normal(pos);
 
-	color = vec4(c, 1.0);
+    vec4 object_color = materials[object_id];
 
-	return intersect;
+    vec3 light_normal = vec3(0.0, 5.0, 0.0) - pos; 
+
+    vec3 color = phong(
+        normal, // object normal
+        object_color.xyz,
+        rv, // camera direction
+        light_normal, // light normal
+        vec3(1.0, 1.0, 0.8), // light Color
+        40.0 // Light strength
+    );
+
+    color *= ambient_occulsion(normal, pos);
+    color *= soft_shadow(pos, light_normal, 4.0);
+    frag_color = vec4(pow(color, vec3(0.4545)), object_color.w);
 }
 
 void main()
 {
-	vec3 intersect = shader(ray_tp, normalize(ray_tv));
-	//vec4 screenPoint = worldToScreen * transform * vec4(intersect, 1);
-	//gl_FragDepth = (screenPoint.z / screenPoint.w + 1) / 2;
+    shader(ray_tp, normalize(ray_tv));
 }

--- a/src/shaders/mandelbulb.frag
+++ b/src/shaders/mandelbulb.frag
@@ -1,0 +1,158 @@
+#version 410 core
+
+#define MAX_LIGHTS 100
+
+in vec3 ray_tp;
+in vec3 ray_tv;
+
+uniform mat4 worldToScreen;
+uniform mat4 transform;
+
+uniform vec3 lightPos[MAX_LIGHTS];
+uniform vec3 lightColor[MAX_LIGHTS];
+uniform int lightNum;
+
+uniform float time;
+
+out vec4 color;
+
+const int MARCH_MAX = 255;
+const float MARCH_MIN_DIST = 0.0f;
+const float MARCH_MAX_DIST = 50.0f;
+const float EPSILON = 0.001f;
+
+float mandelbulb(vec3 p)
+{
+    vec3 w = p;
+    float m = dot(w,w);
+
+    //vec4 trap = vec4(abs(w),m);
+	float dz = 1.0;
+    
+    
+	for(int i=0; i < 4; i++ )
+    {
+        float m2 = m*m;
+        float m4 = m2*m2;
+		dz = 8.0 * sqrt(m4 * m2 * m) * dz + 1.0;
+
+        float x = w.x; float x2 = x*x; float x4 = x2*x2;
+        float y = w.y; float y2 = y*y; float y4 = y2*y2;
+        float z = w.z; float z2 = z*z; float z4 = z2*z2;
+
+        float k3 = x2 + z2;
+        float k2 = inversesqrt(k3 * k3 * k3 * k3 * k3 * k3 * k3);
+        float k1 = x4 + y4 + z4 - 6.0 * y2 * z2 - 6.0 * x2 * y2 + 2.0 * z2 * x2;
+        float k4 = x2 - y2 + z2;
+
+        w.x = p.x +  64.0 * x * y * z * (x2-z2) * k4 * (x4 - 6.0 * x2 * z2 + z4) * k1 * k2;
+        w.y = p.y + -16.0 * y2 * k3 * k4 * k4 + k1 * k1;
+        w.z = p.z +  -8.0 * y * k4 * (x4 * x4 - 28.0 * x4 * x2 * z2 + 70.0 * x4 * z4 - 28.0 * x2 * z2 * z4 + z4 * z4) * k1 * k2;
+        //trap = min(trap, vec4(abs(w), m));
+
+        m = dot(w,w);
+		if (m > 256.0)
+            break;
+    }
+
+    return 0.25 * log(m) * sqrt(m) / dz;
+}
+
+float scene(vec3 p) {
+	// Scaled mandelbox by 0.1
+	return mandelbulb(p * 2.0) / 2.0;
+}
+
+
+float ray_march(vec3 rp, vec3 rv) {
+	float depth = MARCH_MIN_DIST;
+	for (int i = 0; i < MARCH_MAX; ++i)
+	{
+		float min_distance = scene(rp + rv * depth);
+		depth += min_distance;
+		if (min_distance < EPSILON || depth >= MARCH_MAX_DIST) {
+			break;
+		}
+	}
+	return min(depth, MARCH_MAX_DIST);
+}
+
+/* Lighting */
+
+// 1 for less accurate but faster normal, 0 for accurate but slower version.
+
+#if 1
+
+vec3 get_normal(vec3 p) {
+	float ref = scene(p);
+	return normalize(vec3(
+		scene(vec3(p.x + EPSILON, p.y, p.z)) - ref,
+		scene(vec3(p.x, p.y + EPSILON, p.z)) - ref,
+		scene(vec3(p.x, p.y, p.z + EPSILON)) - ref
+	));
+}
+
+#else
+
+vec3 get_normal(vec3 p) {
+    return normalize(vec3(
+        scene(vec3(p.x + EPSILON, p.y, p.z)) - scene(vec3(p.x - EPSILON, p.y, p.z)),
+        scene(vec3(p.x, p.y + EPSILON, p.z)) - scene(vec3(p.x, p.y - EPSILON, p.z)),
+        scene(vec3(p.x, p.y, p.z  + EPSILON)) - scene(vec3(p.x, p.y, p.z - EPSILON))
+    ));
+}
+
+#endif
+
+float ambient_occulsion(vec3 normal, vec3 p)
+{
+	float x = 0.0;
+	x += 0.1 - scene(p + normal * 0.1);
+	x += 0.3 - scene(p + normal * 0.3);
+	x += 0.5 - scene(p + normal * 0.5);
+	return 1.0 - x;
+}
+
+float diffuse(vec3 normal, vec3 ray_dir)
+{
+	return dot(normal, -ray_dir);
+}
+
+float soft_shadow(vec3 intersect, vec3 light_normal, float softness)
+{
+    float res = 1.0;
+    for (float depth = MARCH_MIN_DIST; depth < 20;)
+    {
+        float min_distance = scene(intersect + light_normal * depth);
+        if (min_distance < 0.001)
+            return 0.0;
+        res = min(res, softness * min_distance / depth);
+        depth += min_distance;
+    }
+    return res;
+}
+
+vec3 shader(vec3 rp, vec3 rv) {
+	float dist = ray_march(rp, rv);
+	if (dist > MARCH_MAX_DIST - EPSILON)
+		discard;
+	vec3 intersect = rp + rv * dist;
+	vec3 normal = get_normal(intersect);
+
+	vec3 c = vec3(1.0);
+
+	c *= max(diffuse(normal, rv), 0.2);
+	//c *= ambient_occulsion(normal, intersect);
+	c *= soft_shadow(intersect, vec3(0.0, 1.0, 0.0), 2.0);
+
+	color = vec4(c, 1.0);
+
+	return intersect;
+}
+
+void main()
+{
+	vec3 intersect = shader(ray_tp, normalize(ray_tv));
+	//vec4 screenPoint = worldToScreen * transform * vec4(intersect, 1);
+	//gl_FragDepth = (screenPoint.z / screenPoint.w + 1) / 2;
+}

--- a/src/shaders/marble.frag
+++ b/src/shaders/marble.frag
@@ -14,46 +14,60 @@ uniform int lightNum;
 
 uniform float time;
 
-out vec4 color;
+out vec4 frag_color;
 
 const int MARCH_MAX = 255;
 const float MARCH_MIN_DIST = 0.0f;
-const float MARCH_MAX_DIST = 50.0f;
+const float MARCH_MAX_DIST = 30.0f;
+const float MARCH_VOLUME_DIST = 30.0f;
 const float MARCH_STEP = 0.1f;
 const float EPSILON = 0.001f;
 
-vec4 marble(vec3 p) {
-	return vec4(length(p) - 1.0, );
+const vec4 materials[3] = vec4[](
+	vec4(0.0), // Null Color
+	vec4(1.0, 1.0, 1.0, 0.4), // Clear glass
+	vec4(0.1, 0.1, 1.0, 0.4) // Blue glass
+);
+
+// Clear marble
+float marble(vec3 p, out int object_id) {
+	object_id = 2;
+	float dist = length(p) - 1.0;
+	return dist;
 }
 
 // Distance field representing our scene.
-float scene(vec3 p) {
-	return marble(p);
+float scene(vec3 p, out int object_id) {
+    return marble(p, object_id);
 }
 
-float volume_march(vec3 ro, vec3 rv) {
+// Returns depth traveled inside object.
+float volume_march(vec3 pos, vec3 rv, int object_id) {
 	float inside_dist = 0.0f;
+	int new_object_id;
 	for (float depth = 0.0f; depth < MARCH_MAX_DIST;depth += MARCH_STEP)
 	{
-		float dist = scene(ro + rv * depth);
+		float dist = scene(pos + rv * depth, new_object_id);
 		if (dist <= 0.0) {
 			inside_dist += MARCH_STEP;
 		}
+		if (object_id != new_object_id)
+			break;
 	}
-	return inside_dist;
+    return min(inside_dist, MARCH_MAX_DIST);
 }
 
-float ray_march(vec3 ro, vec3 rv) {
-	float depth = MARCH_MIN_DIST;
-	for (int i = 0; i < MARCH_MAX; ++i)
-	{
-		float min_distance = scene(ro + rv * depth);
-		depth += min_distance;
-		if (min_distance < EPSILON || depth >= MARCH_MAX_DIST) {
-			break;
-		}
-	}
-	return min(depth, MARCH_MAX_DIST);
+float ray_march(vec3 ro, vec3 rv, out int object_id) {
+    float depth = MARCH_MIN_DIST;
+    for (int i = 0; i < MARCH_MAX; ++i)
+    {
+        float min_distance = scene(ro + rv * depth, object_id);
+        depth += min_distance;
+        if (min_distance < EPSILON || depth >= MARCH_MAX_DIST) {
+            break;
+        }
+    }
+    return min(depth, MARCH_MAX_DIST);
 }
 
 /* Lighting */
@@ -63,12 +77,13 @@ float ray_march(vec3 ro, vec3 rv) {
 #if 1
 
 vec3 get_normal(vec3 p) {
-	float ref = scene(p);
-	return normalize(vec3(
-		scene(vec3(p.x + EPSILON, p.y, p.z)) - ref,
-		scene(vec3(p.x, p.y + EPSILON, p.z)) - ref,
-		scene(vec3(p.x, p.y, p.z + EPSILON)) - ref
-	));
+    int _;
+    float ref = scene(p, _);
+    return normalize(vec3(
+        scene(vec3(p.x + EPSILON, p.y, p.z), _) - ref,
+        scene(vec3(p.x, p.y + EPSILON, p.z), _) - ref,
+        scene(vec3(p.x, p.y, p.z + EPSILON), _) - ref
+    ));
 }
 
 #else
@@ -85,24 +100,41 @@ vec3 get_normal(vec3 p) {
 
 float ambient_occulsion(vec3 normal, vec3 p)
 {
-	float x = 0.0;
-	x += 0.1 - scene(p + normal * 0.1);
-	x += 0.3 - scene(p + normal * 0.3);
-	x += 0.5 - scene(p + normal * 0.5);
-	return 1.0 - x;
+    int _;
+    float x = 0.0;
+    x += 0.1 - scene(p + normal * 0.1, _);
+    x += 0.2 - scene(p + normal * 0.2, _);
+    x += 0.3 - scene(p + normal * 0.3, _);
+    return 1.0 - x;
 }
 
-float diffuse(vec3 normal, vec3 light_normal)
+vec3 phong(vec3 pos, vec3 normal, vec3 material_color, vec3 cam_pos, vec3 light_pos, vec3 light_color)
 {
-	return dot(normal, light_normal);
+    vec3 light_normal = light_pos - pos;
+    float distance = length(light_normal);
+    light_normal = normalize(light_normal);
+
+    float diffuse = clamp(dot(normal, light_normal), 0.0, 1.0);
+
+    vec3 reflected_light_dir = normalize(reflect(-light_normal, normal));
+    
+    vec3 cam_dir = normalize(cam_pos - pos);
+    float specular = pow(clamp(dot(reflected_light_dir, cam_dir), 0.0, 1.0), 10.0);
+
+    vec3 diffuse_color = material_color * diffuse;
+    vec3 specular_color = light_color * specular;
+
+    distance *= distance;
+    return (vec3(0.001) + diffuse_color + specular_color) / distance;  
 }
 
-float soft_shadow(vec3 intersect, vec3 light_normal, float softness)
+float soft_shadow(vec3 pos, vec3 light_normal, float softness)
 {
     float res = 1.0;
+    int _;
     for (float depth = 0.01; depth < 20;)
     {
-        float min_distance = scene(intersect + light_normal * depth);
+        float min_distance = scene(pos + light_normal * depth, _);
         if (min_distance < 0.001)
             return 0.0;
         res = min(res, softness * min_distance / depth);
@@ -111,27 +143,44 @@ float soft_shadow(vec3 intersect, vec3 light_normal, float softness)
     return res;
 }
 
-vec3 shader(vec3 ro, vec3 rv) {
-	float dist = ray_march(ro, rv);
-	if (dist > MARCH_MAX_DIST - EPSILON)
-		discard;
-	vec3 intersect = ro + rv * dist;
-	vec3 normal = get_normal(intersect);
+float rand(vec2 co) {
+	return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
+}
 
-	vec3 c = vec3(1.0);
+void shader(vec3 ro, vec3 rv) {
+    int object_id;
+    float dist = ray_march(ro, rv, object_id);
+    if (dist > MARCH_MAX_DIST - EPSILON)
+        discard;
+    vec3 pos = ro + rv * dist;
 
-	c *= max(diffuse(normal, vec3(0.0, 1.0, 0.0)), 0.2);
-	c *= ambient_occulsion(normal, intersect);
-	//c *= soft_shadow(intersect, vec3(0.0, 1.0, 0.0), 2.0);
 
-	color = vec4(c, 1.0);
 
-	return intersect;
+    vec4 object_color = materials[object_id];
+    //float volume_distance = volume_march(pos - rv * ((sin((rv.y * rv.x) * 1000.0) + 1.0) / 1.0), rv, object_id);
+    float volume_distance = volume_march(pos - rv * rand(rv.xy), rv, object_id);
+    object_color.w *= volume_distance;
+
+    vec3 normal = get_normal(pos);
+
+
+    vec3 color = phong(
+        pos, // hit position
+        normal, // object normal
+        object_color.xyz,
+        ro, // camera position
+        vec3(0.0, 1.0, 0.0), // light position
+        vec3(1.0, 1.0, 0.8) // light Color
+    );
+
+    //vec3 color = object_color.xyz;
+    //color *= ambient_occulsion(normal, pos);
+    //color *= soft_shadow(pos, vec3(0.0, 1.0, 0.0), 2.0);
+
+    frag_color = vec4(pow(color, vec3(1.0 / 2.2)), object_color.w);
 }
 
 void main()
 {
-	vec3 intersect = shader(ray_tp, normalize(ray_tv));
-	//vec4 screenPoint = worldToScreen * transform * vec4(intersect, 1);
-	//gl_FragDepth = (screenPoint.z / screenPoint.w + 1) / 2;
+    shader(ray_tp, normalize(ray_tv));
 }

--- a/src/shaders/obj.frag
+++ b/src/shaders/obj.frag
@@ -11,6 +11,6 @@ out vec3 color;
 
 void	main()
 {
-	float modify = abs(dot(normalize(dir_v), normalize(normal_v)));
-	color = texture(tex, uv_v).rgb * modify;
+    float modify = abs(dot(normalize(dir_v), normalize(normal_v)));
+    color = texture(tex, uv_v).rgb * modify;
 }


### PR DESCRIPTION
This pull adds:
* Ambient occlusion and soft shadows (with controllable softness).
* IFS based on a series of folds
* Mandelbulb as our 2nd 3d fractal
* WIP translucent object

In the future I may switch to a hybrid method of AO that uses some combination of the current normal sampling and the ray marcher iterations, this should be basically free and also clear up some of the current method's artifacts.